### PR TITLE
Add Docker-based test runner

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM qgis/qgis:latest
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT ["bash", "-lc", "pytest"]

--- a/README.md
+++ b/README.md
@@ -74,3 +74,29 @@ so you can install it manually with:
 
 In a future release, from [this branch]([https://eurogeojournal.eu/index.php/egj/article/view/553](https://github.com/kauevestena/osm_sidewalkreator/tree/remove_dependencies)) this dependency shall be removed.
 
+
+## Running tests with Docker
+
+The project provides a Docker setup so tests can be executed inside a containerized QGIS environment.
+
+### Build the image
+
+```bash
+docker build -t osm_sidewalkreator-tests .
+```
+
+### Run the tests
+
+Mount the current project directory into the container and execute the test suite:
+
+```bash
+./scripts/run_qgis_tests.sh
+```
+
+This helper script is equivalent to running the image directly:
+
+```bash
+docker run --rm -v "$(pwd)":/app osm_sidewalkreator-tests
+```
+
+Both approaches install Python dependencies from `requirements.txt` and run `pytest` within the QGIS image.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+requests
+folium

--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Determine the plugin root directory (one level up from the script location)
+PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+# Run tests inside the official QGIS container image
+# Mount the plugin directory into /app and execute pytest after installing deps
+exec docker run --rm \
+    -v "${PLUGIN_DIR}:/app" \
+    -w /app \
+    qgis/qgis:latest \
+    bash -lc "pip install -r requirements.txt && pytest"


### PR DESCRIPTION
## Summary
- add `scripts/run_qgis_tests.sh` to run tests inside the official QGIS container
- include a Dockerfile and requirements for containerized testing
- document Docker test workflow in README

## Testing
- `./scripts/run_qgis_tests.sh >/tmp/test.log && tail -n 20 /tmp/test.log` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68958a790a34832f8a64260235251aa9