### PR TITLE
Add CLI options to release script and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,20 @@ docker run --rm -v "$(pwd)":/app osm_sidewalkreator-tests
 ```
 
 Both approaches install Python dependencies from `requirements.txt` and run `pytest` within the QGIS image.
+
+## Creating a release package
+
+The script `release/release_zip.py` bundles the plugin into a ZIP archive for distribution. By default it packages the current repository and writes `osm_sidewalkreator.zip` under `~/sidewalkreator_release`:
+
+```bash
+python release/release_zip.py
+```
+
+You can customize the plugin source, output directory and excluded files:
+
+```bash
+python release/release_zip.py --plugin-dir /path/to/plugin \
+  --output-dir /tmp/build --exclude tests docs "*.pyc"
+```
+
+The `--exclude` option accepts multiple patterns either separated by spaces or by repeating the flag.

--- a/release/release_zip.py
+++ b/release/release_zip.py
@@ -1,19 +1,9 @@
-import os, shutil
+"""Utility script to generate a release zip of the plugin."""
 
-# from zipfile import ZipFile
-# thx: https://thispointer.com/python-how-to-create-a-zip-archive-from-multiple-files-or-directory/
-
+import argparse
+import os
+import shutil
 from pathlib import Path
-
-"""
-
-    RELEASE SYSTEM FOR THE PLUGIN
-
-    you just need to include in the list "exclude_patternslist" the patterns that should not be included in the release 
-
-    it will export the zip file to a folder named "sidewalkreator_release" to the homefolder
-
-"""
 
 
 exclude_patternslist = [
@@ -32,37 +22,66 @@ exclude_patternslist = [
 ]
 
 
-# print(filelist)
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments for release generation."""
 
-this_file_path = os.path.realpath(__file__)
-plugin_path = os.path.dirname(os.path.dirname(this_file_path))
+    default_plugin_dir = Path(__file__).resolve().parent.parent
+    default_output_dir = Path.home() / "sidewalkreator_release"
+
+    parser = argparse.ArgumentParser(description="Package plugin into a zip archive")
+    parser.add_argument(
+        "--plugin-dir",
+        default=str(default_plugin_dir),
+        help="Path to the plugin directory (default: repository root)",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default=str(default_output_dir),
+        help="Directory where the release zip will be written",
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        nargs="*",
+        default=[],
+        help="Additional patterns to exclude from the archive",
+    )
+
+    return parser.parse_args()
 
 
-destfolderpath = str(
-    Path.home() / "sidewalkreator_release" / "osm_sidewalkreator" / "osm_sidewalkreator"
-)
+def main() -> None:
+    args = parse_args()
 
-release_folderpath = str(Path(destfolderpath).parent)
+    plugin_path = os.path.abspath(os.path.expanduser(args.plugin_dir))
+    output_dir = os.path.abspath(os.path.expanduser(args.output_dir))
 
-outpath = os.path.join(
-    os.path.expanduser("~"), "sidewalkreator_release", "osm_sidewalkreator.zip"
-)
+    additional_excludes = [p for patterns in args.exclude for p in patterns]
+    exclude_patterns = exclude_patternslist + additional_excludes
+
+    destfolderpath = str(
+        Path(output_dir) / "osm_sidewalkreator" / "osm_sidewalkreator"
+    )
+    release_folderpath = str(Path(destfolderpath).parent)
+    outpath = os.path.join(output_dir, "osm_sidewalkreator.zip")
+
+    if os.path.exists(release_folderpath):
+        shutil.rmtree(release_folderpath)
+
+    shutil.copytree(
+        plugin_path, destfolderpath, ignore=shutil.ignore_patterns(*exclude_patterns)
+    )
+
+    if os.path.exists(outpath):
+        os.remove(outpath)
+
+    shutil.make_archive(outpath.replace(".zip", ""), "zip", release_folderpath)
+
+    print(outpath)
+    print(release_folderpath)
+    print(destfolderpath)
 
 
-if os.path.exists(release_folderpath):
-    shutil.rmtree(release_folderpath)
+if __name__ == "__main__":
+    main()
 
-# thx: https://stackoverflow.com/a/42488524/4436950
-shutil.copytree(
-    plugin_path, destfolderpath, ignore=shutil.ignore_patterns(*exclude_patternslist)
-)
-
-if os.path.exists(outpath):
-    os.remove(outpath)
-
-
-shutil.make_archive(outpath.replace(".zip", ""), "zip", release_folderpath)
-
-print(outpath)
-print(release_folderpath)
-print(destfolderpath)


### PR DESCRIPTION
## Summary
- add `argparse` flags for plugin directory, output directory and exclusions
- document release script usage in README

## Testing
- `pytest` *(fails: No module named 'osgeo')*


------
https://chatgpt.com/codex/tasks/task_b_6895f7af0c3c832f8eca285c390a0e9a