### PR TITLE
Support release artifact testing in CI

### DIFF
--- a/.github/workflows/task1.yml
+++ b/.github/workflows/task1.yml
@@ -1,0 +1,14 @@
+name: Task 1
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run QGIS tests against release
+        run: ./scripts/run_qgis_tests.sh --use-release
+

--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ Mount the current project directory into the container and execute the test suit
 ./scripts/run_qgis_tests.sh
 ```
 
+To run tests against the generated release zip, pass the `--use-release` flag:
+
+```bash
+./scripts/run_qgis_tests.sh --use-release
+```
+
 This helper script is equivalent to running the image directly:
 
 ```bash

--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -4,11 +4,25 @@ set -euo pipefail
 # Determine the plugin root directory (one level up from the script location)
 PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
-# Run tests inside the official QGIS container image
-# Mount the plugin directory into /app and execute pytest after installing deps
-exec docker run --rm \
-    -v "${PLUGIN_DIR}:/app" \
-    -w /app \
-    -e PYTHONPATH=/app:/app/test \
-    qgis/qgis:latest \
-    bash -lc "pip install -r requirements.txt && pytest"
+USE_RELEASE=false
+if [[ ${1:-} == "--use-release" ]]; then
+    USE_RELEASE=true
+fi
+
+if ${USE_RELEASE}; then
+    ZIP_OUTPUT="$(python "${PLUGIN_DIR}/release/release_zip.py")"
+    ZIP_PATH="$(printf "%s" "$ZIP_OUTPUT" | head -n1)"
+
+    exec docker run --rm \
+        -v "${ZIP_PATH}:/tmp/osm_sidewalkreator.zip" \
+        -e PYTHONPATH=/tmp/osm_sidewalkreator:/tmp/osm_sidewalkreator/test \
+        qgis/qgis:latest \
+        bash -lc "unzip /tmp/osm_sidewalkreator.zip -d /tmp && cd /tmp/osm_sidewalkreator && pip install -r requirements.txt && pytest"
+else
+    exec docker run --rm \
+        -v "${PLUGIN_DIR}:/app" \
+        -w /app \
+        -e PYTHONPATH=/app:/app/test \
+        qgis/qgis:latest \
+        bash -lc "pip install -r requirements.txt && pytest"
+fi


### PR DESCRIPTION
## Summary
- Add `--use-release` flag to run_qgis_tests.sh to build and test release zips
- Run release tests in new Task 1 GitHub workflow
- Document release testing flag in README

## Testing
- `apt-get update`
- `apt-get install -y docker.io`
- `./scripts/run_qgis_tests.sh --use-release` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*


------
https://chatgpt.com/codex/tasks/task_b_6896168f9b74832fb0fc25c32060d16f