### PR TITLE
Add processing runner script and release flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,33 +48,6 @@ It is mostly intended for Acessibility Mapping.
 
 Though the data was generated thinking on the usage for OSM, one may use it for pedestrian network analysis out-of-the-box, or even for other purposes inside or outside QGIS.
 
-## Known Issues:
-
-The only dependency (osm2geojson) have shapely as dependency, but sadly it doesn't come bundled with QGIS, 
-so you can install it manually with:
-
-    <qgis_python_path> -m pip install shapely
-
-### For Flatpak QGIS:
-
-1) Open the flatpak shell for the qgis package:
-
-
-    flatpak run --command=sh org.qgis.qgis
-   
-3) Within the shell, type:
-
-
-    curl https://bootstrap.pypa.io/pip/pip.pyz -o pip.pyz
-   
-5) Install shapely:
-
-
-    python3 pip.pyz install shapely
-
-In a future release, from [this branch]([https://eurogeojournal.eu/index.php/egj/article/view/553](https://github.com/kauevestena/osm_sidewalkreator/tree/remove_dependencies)) this dependency shall be removed.
-
-
 ## Running tests with Docker
 
 The project provides a Docker setup so tests can be executed inside a containerized QGIS environment.
@@ -91,6 +64,8 @@ Mount the current project directory into the container and execute the test suit
 
 ```bash
 ./scripts/run_qgis_tests.sh
+# or to test a packaged release
+./scripts/run_qgis_tests.sh --use-release
 ```
 
 This helper script is equivalent to running the image directly:
@@ -100,6 +75,25 @@ docker run --rm -v "$(pwd)":/app osm_sidewalkreator-tests
 ```
 
 Both approaches install Python dependencies from `requirements.txt` and run `pytest` within the QGIS image.
+
+### Run processing algorithms
+
+The `scripts/run_qgis_processing.sh` helper invokes QGIS Processing algorithms
+from this plugin inside the same containerized environment. It mirrors the
+`--use-release` flag of the test script so algorithms can be executed from the
+source tree or a built release ZIP.
+
+Run an algorithm against the source tree:
+
+```bash
+./scripts/run_qgis_processing.sh generateprotoblocksfromosm INPUT=/path/to/input.geojson OUTPUT=/tmp/out.gpkg
+```
+
+Or run it using a release build:
+
+```bash
+./scripts/run_qgis_processing.sh --use-release generateprotoblocksfromosm INPUT=/path/to/input.geojson OUTPUT=/tmp/out.gpkg
+```
 
 ## Creating a release package
 

--- a/scripts/run_qgis_processing.sh
+++ b/scripts/run_qgis_processing.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+USE_RELEASE=0
+if [[ "${1:-}" == "--use-release" ]]; then
+    USE_RELEASE=1
+    shift
+fi
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 [--use-release] <algorithm_id> [qgis_process parameters...]" >&2
+    exit 1
+fi
+
+ALGO_ID="$1"
+shift
+PARAMS="$*"
+
+PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+
+if [[ ${USE_RELEASE} -eq 1 ]]; then
+    RELEASE_OUTPUT=$(python "${PLUGIN_DIR}/release/release_zip.py")
+    ZIP_PATH=$(echo "${RELEASE_OUTPUT}" | sed -n '1p')
+    DOCKER_CMD="apt-get update -qq && apt-get install -y unzip >/dev/null && unzip /tmp/plugin.zip -d /tmp/plugin && export PYTHONPATH=/tmp/plugin/osm_sidewalkreator && qgis_process run sidewalkreator_algorithms_provider:${ALGO_ID} ${PARAMS}"
+    exec docker run --rm \
+        -v "${ZIP_PATH}:/tmp/plugin.zip" \
+        qgis/qgis:latest \
+        bash -lc "${DOCKER_CMD}"
+else
+    DOCKER_CMD="export PYTHONPATH=/app && qgis_process run sidewalkreator_algorithms_provider:${ALGO_ID} ${PARAMS}"
+    exec docker run --rm \
+        -v "${PLUGIN_DIR}:/app" \
+        qgis/qgis:latest \
+        bash -lc "${DOCKER_CMD}"
+fi
+

--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -4,11 +4,27 @@ set -euo pipefail
 # Determine the plugin root directory (one level up from the script location)
 PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 
-# Run tests inside the official QGIS container image
-# Mount the plugin directory into /app and execute pytest after installing deps
-exec docker run --rm \
-    -v "${PLUGIN_DIR}:/app" \
-    -w /app \
-    -e PYTHONPATH=/app:/app/test \
-    qgis/qgis:latest \
-    bash -lc "pip install -r requirements.txt && pytest"
+USE_RELEASE=0
+if [[ "${1:-}" == "--use-release" ]]; then
+    USE_RELEASE=1
+    shift
+fi
+
+if [[ ${USE_RELEASE} -eq 1 ]]; then
+    RELEASE_OUTPUT=$(python "${PLUGIN_DIR}/release/release_zip.py")
+    ZIP_PATH=$(echo "${RELEASE_OUTPUT}" | sed -n '1p')
+    DOCKER_CMD="apt-get update -qq && apt-get install -y unzip >/dev/null && unzip /tmp/plugin.zip -d /tmp/plugin && cd /tmp/plugin/osm_sidewalkreator && export PYTHONPATH=/tmp/plugin/osm_sidewalkreator:/tmp/plugin/osm_sidewalkreator/test && pip install -r requirements.txt && pytest"
+    exec docker run --rm \
+        -v "${ZIP_PATH}:/tmp/plugin.zip" \
+        qgis/qgis:latest \
+        bash -lc "${DOCKER_CMD}"
+else
+    # Run tests inside the official QGIS container image
+    # Mount the plugin directory into /app and execute pytest after installing deps
+    exec docker run --rm \
+        -v "${PLUGIN_DIR}:/app" \
+        -w /app \
+        -e PYTHONPATH=/app:/app/test \
+        qgis/qgis:latest \
+        bash -lc "pip install -r requirements.txt && pytest"
+fi


### PR DESCRIPTION
## Summary
- extend `scripts/run_qgis_tests.sh` with a `--use-release` option to test the packaged plugin
- add `scripts/run_qgis_processing.sh` to run plugin processing algorithms via `qgis_process`
- ensure Docker runs install `unzip` when testing or processing against a release zip
- document the new scripts and `--use-release` flag in the README
- remove outdated references to the shapely dependency from the documentation

## Testing
- `./scripts/run_qgis_tests.sh` *(fails: line 24: exec: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68962cfb9c04832fac8948faf057d3f1