### PR TITLE
Replace debug print with logging

### DIFF
--- a/osm_sidewalkreator.py
+++ b/osm_sidewalkreator.py
@@ -50,6 +50,7 @@ from qgis.core import (
     QgsGeometryUtils,
     QgsFeatureRequest,
     Qgis,
+    QgsMessageLog,
     NULL,
     QgsStatisticalSummary,
 )
@@ -108,7 +109,11 @@ base_pluginpath_p2 = "python/plugins/osm_sidewalkreator"
 basepath = os.path.join(profilepath, base_pluginpath_p2)
 temps_path = os.path.join(basepath, "temporary")
 
-print(basepath)
+QgsMessageLog.logMessage(
+    f"Plugin base path: {basepath}",
+    "SidewalKreator",
+    Qgis.Info,
+)
 reports_path = os.path.join(basepath, "reports")
 
 assets_path = os.path.join(basepath, "assets")


### PR DESCRIPTION
## Summary
- use QgsMessageLog to report plugin base path instead of printing to stdout

## Testing
- `scripts/run_qgis_tests.sh` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689762aecbdc832f8cbc71b2306dc80e