### PR TITLE
chore: use prebuilt qgis image for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,11 @@
 FROM qgis/qgis:latest
 
-WORKDIR /app
-COPY . /app
+# Install system packages and Python dependencies needed for tests
+RUN apt-get update -qq \
+    && apt-get install -y --no-install-recommends unzip \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN pip install --no-cache-dir -r requirements.txt
-
-ENTRYPOINT ["bash", "-lc", "pytest"]
+# Pre-install Python requirements so containers run tests immediately
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt \
+    && rm /tmp/requirements.txt

--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -13,10 +13,10 @@ fi
 if [[ ${USE_RELEASE} -eq 1 ]]; then
     RELEASE_OUTPUT=$(python "${PLUGIN_DIR}/release/release_zip.py")
     ZIP_PATH=$(echo "${RELEASE_OUTPUT}" | sed -n '1p')
-    DOCKER_CMD="apt-get update -qq && apt-get install -y unzip >/dev/null && unzip /tmp/plugin.zip -d /tmp/plugin && cd /tmp/plugin/osm_sidewalkreator && export PYTHONPATH=/tmp/plugin/osm_sidewalkreator:/tmp/plugin/osm_sidewalkreator/test && pip install -r requirements.txt && pytest"
+    DOCKER_CMD="unzip /tmp/plugin.zip -d /tmp/plugin && cd /tmp/plugin/osm_sidewalkreator && export PYTHONPATH=/tmp/plugin/osm_sidewalkreator:/tmp/plugin/osm_sidewalkreator/test && pytest"
     exec docker run --rm \
         -v "${ZIP_PATH}:/tmp/plugin.zip" \
-        qgis/qgis:latest \
+        my-org/qgis-test:latest \
         bash -lc "${DOCKER_CMD}"
 else
     # Run tests inside the official QGIS container image
@@ -26,6 +26,6 @@ else
         -v "${PLUGIN_DIR}:/app" \
         -w /app \
         -e PYTHONPATH=/app:/app/test \
-        qgis/qgis:latest \
-        bash -lc "pip install -r requirements.txt && pytest"
+        my-org/qgis-test:latest \
+        bash -lc "pytest"
 fi


### PR DESCRIPTION
## Summary
- pre-install unzip and Python deps in a new QGIS-based test image
- run tests using `my-org/qgis-test:latest` without in-container package installs

## Testing
- `docker build -t my-org/qgis-test:latest .` *(fails: Cannot connect to the Docker daemon)*
- `docker push my-org/qgis-test:latest` *(fails: Cannot connect to the Docker daemon)*
- `scripts/run_qgis_tests.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_68982b739390832f8d108c3145b2a05f