### PR TITLE
Ensure run_qgis_tests verifies Docker availability

### DIFF
--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -2,15 +2,15 @@
 set -euo pipefail
 
 # Ensure Docker is installed and the daemon is accessible
-command -v docker >/dev/null 2>&1 || {
+if ! command -v docker >/dev/null 2>&1; then
     echo "Error: Docker is not installed or not in PATH." >&2
     exit 1
-}
+fi
 
-docker info >/dev/null 2>&1 || {
+if ! docker info >/dev/null 2>&1; then
     echo "Error: Docker daemon is not running or not reachable." >&2
     exit 1
-}
+fi
 
 # Determine the plugin root directory (one level up from the script location)
 PLUGIN_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"


### PR DESCRIPTION
## Summary
- verify Docker installation and daemon before running QGIS tests

## Testing
- `scripts/run_qgis_tests.sh` *(fails: Error: Docker is not installed or not in PATH.)*

------
https://chatgpt.com/codex/tasks/task_b_68982b78dc00832fbb7b294875461591