### PR TITLE
Fix missing CRS import in sidewalk generation logic

### DIFF
--- a/processing/sidewalk_generation_logic.py
+++ b/processing/sidewalk_generation_logic.py
@@ -12,6 +12,7 @@ from qgis.core import (
     QgsWkbTypes,
     QgsProcessingException,
     Qgis,
+    QgsCoordinateReferenceSystem,
     edit,
 )
 


### PR DESCRIPTION
## Summary
- Import `QgsCoordinateReferenceSystem` in sidewalk_generation_logic to allow Processing provider registration

## Testing
- `scripts/run_qgis_tests.sh` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a3fc1f48c832f999e25f8d8c41b17