### PR TITLE
Fix missing CRS import and add road network cleaning helper

### DIFF
--- a/generic_functions.py
+++ b/generic_functions.py
@@ -423,6 +423,52 @@ def reproject_layer(
     return processing.run("native:reprojectlayer", parameter_dict)["OUTPUT"]
 
 
+def clean_street_network_data(
+    osm_layer,
+    clip_polygon_layer,
+    local_tm_crs,
+    layer_name,
+    feedback=None,
+    context=None,
+):
+    """Clip OSM road data to the input polygon and reproject to a local TM CRS.
+
+    Parameters
+    ----------
+    osm_layer : QgsVectorLayer
+        Road data in EPSG:4326.
+    clip_polygon_layer : QgsVectorLayer
+        Polygon layer defining the area of interest (also in EPSG:4326).
+    local_tm_crs : QgsCoordinateReferenceSystem
+        Destination CRS for local Transverse Mercator projection.
+    layer_name : str
+        Name for the resulting memory layer.
+    feedback : QgsProcessingFeedback, optional
+        Processing feedback object.
+    context : QgsProcessingContext, optional
+        Processing context.
+
+    Returns
+    -------
+    QgsVectorLayer
+        Cleaned and reprojected road layer in ``local_tm_crs``.
+    """
+
+    clipped = cliplayer_v2(osm_layer, clip_polygon_layer)
+
+    params = {
+        "INPUT": clipped,
+        "TARGET_CRS": local_tm_crs,
+        "OUTPUT": f"memory:{layer_name}",
+    }
+
+    result = processing.run(
+        "native:reprojectlayer", params, context=context, feedback=feedback
+    )["OUTPUT"]
+    result.setCrs(local_tm_crs)
+    return result
+
+
 def split_lines(inputlayer, splitterlayer, outputlayer="TEMPORARY_OUTPUT"):
 
     parameter_dict = {

--- a/processing/full_sidewalkreator_bbox_algorithm.py
+++ b/processing/full_sidewalkreator_bbox_algorithm.py
@@ -42,7 +42,7 @@ from ..generic_functions import (
     reproject_layer,
     # log_plugin_message,
     cliplayer_v2,
-    # clean_street_network_data,
+    clean_street_network_data,
     # create_memory_layer_from_features,
 )
 from ..parameters import CRS_LATLON_4326

--- a/processing/sidewalk_generation_logic.py
+++ b/processing/sidewalk_generation_logic.py
@@ -12,6 +12,7 @@ from qgis.core import (
     QgsWkbTypes,
     QgsProcessingException,
     Qgis,
+    QgsCoordinateReferenceSystem,
     edit,
 )
 


### PR DESCRIPTION
## Summary
- Import `QgsCoordinateReferenceSystem` in sidewalk_generation_logic to allow Processing provider registration
- Implement `clean_street_network_data` to clip and reproject OSM roads for the BBOX algorithm

## Testing
- `scripts/run_qgis_tests.sh` *(fails: docker: not found)*

------
https://chatgpt.com/codex/tasks/task_b_689a3fc1f48c832f999e25f8d8c41b17