### PR TITLE
Include latitude in local TM reprojection

### DIFF
--- a/generic_functions.py
+++ b/generic_functions.py
@@ -625,8 +625,20 @@ def custom_local_projection(lgt_0, lat_0=0, mode="TM", return_wkt=False):
 
 
 def reproject_layer_localTM(inputlayer, outputpath, layername, lgt_0, lat_0=0):
-    """
-    pass None to "outputpath" in order to use an only memory layer
+    """Reproject a layer to a custom local Transverse Mercator CRS.
+
+    Parameters
+    ----------
+    inputlayer: QgsVectorLayer
+        Layer to reproject.
+    outputpath: str or None
+        Destination path. Pass ``None`` to create an in-memory layer.
+    layername: str
+        Name for the resulting layer when ``outputpath`` is ``None``.
+    lgt_0: float
+        Central meridian (``lon_0``) for the custom CRS.
+    lat_0: float, optional
+        Latitude of origin (``lat_0``) for the custom CRS.
     """
 
     # https://docs.qgis.org/3.16/en/docs/user_manual/processing_algs/qgis/vectorgeneral.html#reproject-layer

--- a/processing/full_sidewalkreator_bbox_algorithm.py
+++ b/processing/full_sidewalkreator_bbox_algorithm.py
@@ -351,6 +351,7 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
             extent_4326 = transform.transform(extent_4326)
 
         centroid_lon = extent_4326.center().x()
+        centroid_lat = extent_4326.center().y()
 
         # Reproject the memory input polygon layer to local TM for internal processing
         # The reproject_layer_localTM function handles the creation of the CRS internally
@@ -360,6 +361,7 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
             None,
             "input_poly_local_tm",
             centroid_lon,
+            centroid_lat,
         )
         if not local_tm_crs.isValid():
             feedback.reportError(
@@ -592,6 +594,7 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
                         None,
                         f"bldgs_local_tm_bbox_{context.algorithm().id()[:5]}",
                         centroid_lon,
+                        centroid_lat,
                     )
                     if (
                         not reproj_buildings_layer_local_tm

--- a/test/test_processing_algorithms.py
+++ b/test/test_processing_algorithms.py
@@ -125,7 +125,7 @@ def _patch_full_bbox_alg(monkeypatch, raise_in_generation=False):
         tmp.close()
         return tmp.name
 
-    def fake_reproject(layer, outputpath=None, layername=None, lgt_0=None):
+    def fake_reproject(layer, outputpath=None, layername=None, lgt_0=None, lat_0=0):
         from qgis.core import QgsCoordinateReferenceSystem
 
         return layer, QgsCoordinateReferenceSystem("EPSG:4326")
@@ -223,7 +223,7 @@ def _patch_full_polygon_alg(monkeypatch, call_recorder, raise_in_generation=Fals
             }
         )
 
-    def fake_reproject(layer, outputpath=None, layername=None, lgt_0=None):
+    def fake_reproject(layer, outputpath=None, layername=None, lgt_0=None, lat_0=0):
         from qgis.core import QgsCoordinateReferenceSystem
 
         return layer, QgsCoordinateReferenceSystem("EPSG:4326")


### PR DESCRIPTION
## Summary
- compute centroid latitude for bounding box inputs
- allow reproject_layer_localTM to use both lon and lat origins in custom CRS
- adjust tests for updated signature

## Testing
- `scripts/run_qgis_tests.sh` *(fails: Cannot connect to the Docker daemon)*

------
https://chatgpt.com/codex/tasks/task_b_689a5d26ed18832fb7108ea0ffc62ada