### PR TITLE
Validate EPSG:4326 extents in bbox sidewalk generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ from this plugin inside the same containerized environment. It mirrors the
 `--use-release` flag of the test script so algorithms can be executed from the
 source tree or a built release ZIP.
 
+> **Note**
+> Algorithms that accept a bounding box require the extent coordinates to be
+> in EPSG:4326. Supplying extents outside valid latitude/longitude bounds or
+> using another CRS will result in a helpful error asking for EPSG:4326
+> coordinates or an explicit CRS.
+
 Run an algorithm against the source tree:
 
 ```bash

--- a/processing/full_sidewalkreator_bbox_algorithm.py
+++ b/processing/full_sidewalkreator_bbox_algorithm.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-from qgis.PyQt.QtCore import QCoreApplication
 from qgis.core import (
     QgsProcessing,
     QgsProcessingAlgorithm,
@@ -23,6 +22,7 @@ from qgis.core import (
     QgsFields,
     QgsFeatureRequest,
     QgsProcessingUtils,
+    QgsProcessingException,
     QgsMessageLog,
     Qgis,
 )
@@ -303,6 +303,21 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
                 f"Input extent: {input_extent_rect.asWktPolygon()} (CRS: EPSG:4326 assumed for extent parameter)"
             )
         )
+
+        project_crs = context.project().crs()
+        extent_within_latlon = (
+            -180 <= input_extent_rect.xMinimum() <= 180
+            and -180 <= input_extent_rect.xMaximum() <= 180
+            and -90 <= input_extent_rect.yMinimum() <= 90
+            and -90 <= input_extent_rect.yMaximum() <= 90
+        )
+        if project_crs.authid() != CRS_LATLON_4326 and not extent_within_latlon:
+            msg = self.tr(
+                "Extent coordinates appear outside valid latitude/longitude bounds."
+                " Please supply coordinates in EPSG:4326 or specify the CRS."
+            )
+            feedback.reportError(msg, True)
+            raise QgsProcessingException(msg)
 
         # Create a QgsGeometry from the QgsRectangle
         input_polygon_geom = QgsGeometry.fromRect(input_extent_rect)

--- a/test/test_processing_algorithms.py
+++ b/test/test_processing_algorithms.py
@@ -8,6 +8,8 @@ from qgis.core import (
     QgsGeometry,
     QgsPointXY,
     QgsProcessingException,
+    QgsProject,
+    QgsCoordinateReferenceSystem,
 )
 from qgis import processing
 
@@ -360,6 +362,29 @@ def test_full_bbox_failure(monkeypatch):
             "sidewalkreator_algorithms_provider:osm_sidewalkreator_full_bbox",
             params,
         )
+
+
+def test_full_bbox_invalid_extent(monkeypatch):
+    _patch_full_bbox_alg(monkeypatch)
+    project = QgsProject.instance()
+    old_crs = project.crs()
+    project.setCrs(QgsCoordinateReferenceSystem("EPSG:3857"))
+    params = {
+        "INPUT_EXTENT": "20037508,0,20037509,1 [EPSG:3857]",
+        "TIMEOUT": 30,
+        "GET_BUILDING_DATA": False,
+        "DEFAULT_WIDTH": 2.0,
+        "MIN_WIDTH": 1.0,
+        "MAX_WIDTH": 5.0,
+        "STREET_CLASSES": [10],
+        "OUTPUT_SIDEWALKS": "memory:sidewalks",
+    }
+    with pytest.raises(QgsProcessingException):
+        processing.run(
+            "sidewalkreator_algorithms_provider:osm_sidewalkreator_full_bbox",
+            params,
+        )
+    project.setCrs(old_crs)
 
 
 # ---------------------- Full Sidewalkreator Polygon Algorithm Tests ----------------------


### PR DESCRIPTION
## Summary
- verify bbox extents are within lat/lon or project CRS is EPSG:4326
- document EPSG:4326 requirement for bbox algorithms
- test invalid extents trigger processing exception
- drop duplicate QCoreApplication import from bbox algorithm

## Testing
- `scripts/run_qgis_tests.sh` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_b_689a70f14d28832f8c0af04e1d549632