### PR TITLE
Use outputlayer in polygonize_lines and add context forwarding

### DIFF
--- a/generic_functions.py
+++ b/generic_functions.py
@@ -190,7 +190,13 @@ def merge_touching_lines(inputlayer, outputlayer="TEMPORARY_OUTPUT"):
     return processing.run("native:mergelines", parameter_dict)["OUTPUT"]
 
 
-def polygonize_lines(inputlines, outputlayer="TEMPORARY_OUTPUT", keepfields=True):
+def polygonize_lines(
+    inputlines,
+    outputlayer="TEMPORARY_OUTPUT",
+    keepfields=True,
+    context=None,
+    feedback=None,
+):
     # Ensure that the outputlayer string results in a QgsVectorLayer object being returned by processing.run
     # For memory layers, the 'OUTPUT' value in the returned dict IS the QgsVectorLayer instance.
     parameter_dict = {
@@ -198,24 +204,9 @@ def polygonize_lines(inputlines, outputlayer="TEMPORARY_OUTPUT", keepfields=True
         "OUTPUT": outputlayer,  # e.g., 'memory:my_polygonized_layer'
         "KEEP_FIELDS": keepfields,
     }
-    result_layer = processing.run("native:polygonize", parameter_dict)["OUTPUT"]
-
-    # It's good practice to ensure the CRS is what we expect,
-    # though native:polygonize should set it based on input.
-    # if isinstance(result_layer, QgsVectorLayer) and inputlines.crs().isValid():
-    #     if not result_layer.crs().isValid() or result_layer.crs() != inputlines.crs():
-    #         print(f"Warning: CRS mismatch or invalid CRS after polygonize. Input CRS: {inputlines.crs().authid()}, Output CRS: {result_layer.crs().authid()}. Forcing input CRS.")
-    #         result_layer.setCrs(inputlines.crs()) # Ensure CRS is set from input
-    # return result_layer # Old direct return
-
-    # Ensure that the outputlayer string results in a QgsVectorLayer object being returned by processing.run
-    # For memory layers, the 'OUTPUT' value in the returned dict IS the QgsVectorLayer instance.
-    parameter_dict = {
-        "INPUT": inputlines,
-        "OUTPUT": outputlayer,  # e.g., 'memory:my_polygonized_layer'
-        "KEEP_FIELDS": keepfields,
-    }
-    result_layer = processing.run("native:polygonize", parameter_dict)["OUTPUT"]
+    result_layer = processing.run(
+        "native:polygonize", parameter_dict, context=context, feedback=feedback
+    )["OUTPUT"]
 
     # It's good practice to ensure the CRS is what we expect,
     # though native:polygonize should set it based on input.

--- a/processing/full_sidewalkreator_bbox_algorithm.py
+++ b/processing/full_sidewalkreator_bbox_algorithm.py
@@ -495,9 +495,7 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
         feedback.pushInfo(self.tr("Generating protoblocks..."))
         protoblocks_layer_local_tm = polygonize_lines(
             cleaned_roads_local_tm,
-            output_layer_name="protoblocks_local_tm_bbox",
-            feedback=feedback,
-            context=context,
+            outputlayer="memory:protoblocks_local_tm_bbox",
         )
         if (
             not protoblocks_layer_local_tm


### PR DESCRIPTION
## Summary
- switch bbox algorithm to use `outputlayer` when polygonizing protoblocks
- allow `polygonize_lines` to forward processing context and feedback

## Testing
- `scripts/run_qgis_tests.sh` *(fails: docker: not found)*
- `PYTHONPATH=/usr/lib/python3/dist-packages pytest` *(fails: ImportError while importing test modules)*

------
https://chatgpt.com/codex/tasks/task_b_689b4ed9b9f0832fbae23ebc22e6c60d