### PR TITLE
Handle missing Docker in test script

### DIFF
--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,2 +1,6 @@
-# import qgis libs so that ve set the correct sip api version
-import qgis  # pylint: disable=W0611  # NOQA
+# Import QGIS libs to set the correct SIP API version when available.
+# Allow the tests to run without QGIS by ignoring missing module errors.
+try:
+    import qgis  # pylint: disable=W0611  # NOQA
+except ModuleNotFoundError:
+    pass


### PR DESCRIPTION
## Summary
- Install GDAL dependencies when Docker is unavailable
- Allow test package to import without QGIS

## Testing
- `bash scripts/run_qgis_tests.sh` *(hangs on Overpass request; interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_689b51ce6bbc832f8b076649f8f8f32d