### PR TITLE
Handle QGIS geometry perimeter API

### DIFF
--- a/processing/full_sidewalkreator_bbox_algorithm.py
+++ b/processing/full_sidewalkreator_bbox_algorithm.py
@@ -552,7 +552,7 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
                         context,
                         protoblocks_layer_4326_debug.fields(),
                         protoblocks_layer_4326_debug.wkbType(),
-                        CRS_LATLON_4326,
+                        QgsCoordinateReferenceSystem(CRS_LATLON_4326),
                     )
                 )
                 if sink_protoblocks_debug:
@@ -742,7 +742,7 @@ class FullSidewalkreatorBboxAlgorithm(QgsProcessingAlgorithm):
                     context,
                     sidewalks_layer_4326.fields(),
                     sidewalks_layer_4326.wkbType(),
-                    CRS_LATLON_4326,
+                    QgsCoordinateReferenceSystem(CRS_LATLON_4326),
                 )
                 if sink_sidewalks:
                     for feature in sidewalks_layer_4326.getFeatures():

--- a/processing/sidewalk_generation_logic.py
+++ b/processing/sidewalk_generation_logic.py
@@ -60,8 +60,8 @@ def filter_polygons_by_area_perimeter_ratio(
     ids_to_remove = []
     for feat in polygon_layer.getFeatures():
         geom = feat.geometry()
-        perim = geom.perimeter()
-        if perim == 0:
+        perim = geom.perimeter() if hasattr(geom, "perimeter") else geom.length()
+        if perim <= 0:
             continue
         area = geom.area()
         if (area / perim) < ratio_threshold:


### PR DESCRIPTION
## Summary
- use geometry length as perimeter and guard for pre-3.30 QGIS API
- ensure BBOX sidewalk sink uses CRS objects instead of strings

## Testing
- `scripts/run_qgis_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_689bd5cf7478832f88aca5e058f22463