### PR TITLE
Handle width field assignment safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,12 @@ pip install -r requirements.txt
 pytest -m "not qgis"
 ```
 
-The `not qgis` marker skips tests that need a QGIS environment, providing a quicker feedback loop.
+The development requirements include the GDAL Python bindings used by the
+`osm_fetch` module. If your platform does not ship pre-built wheels you may
+need to install system GDAL libraries (e.g. `libgdal-dev`) before running the
+command above. When using `scripts/run_qgis_tests.sh` on Debian-based systems,
+these packages are installed automatically if missing. The `not qgis` marker
+skips tests that need a QGIS environment, providing a quicker feedback loop.
 
 ### Regenerating test data
 

--- a/generic_functions.py
+++ b/generic_functions.py
@@ -1749,7 +1749,6 @@ def assign_street_widths(
     # Get field indices
     highway_field_idx_source = source_fields.lookupField(highway_tag)
     width_field_idx_source = source_fields.lookupField(widths_fieldname)
-    width_field_idx_target = output_layer.fields().lookupField(widths_fieldname)
 
     features_to_add = []
     for feature in source_road_layer.getFeatures():
@@ -1784,7 +1783,7 @@ def assign_street_widths(
             new_feat = QgsFeature(output_layer.fields())
             new_feat.setGeometry(feature.geometry())
             new_feat.setAttributes(feature.attributes())
-            new_feat.setAttribute(width_field_idx_target, final_width)
+            new_feat.setAttribute(widths_fieldname, final_width)
             features_to_add.append(new_feat)
 
     if features_to_add:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
 markers =
     qgis: tests requiring QGIS
+testpaths =
+    test

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 requests
 folium
+gdal==3.8.4  # GDAL bindings required for osgeo-based tests

--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -45,6 +45,15 @@ else
     cd "${PLUGIN_DIR}"
     export PYTHONPATH="${PLUGIN_DIR}:${PLUGIN_DIR}/test"
     export PIP_BREAK_SYSTEM_PACKAGES=1
+    if ! command -v gdal-config >/dev/null 2>&1; then
+        if command -v apt-get >/dev/null 2>&1; then
+            apt-get update -qq
+            apt-get install -y gdal-bin libgdal-dev >/dev/null
+        else
+            echo "gdal-config not found. Please install GDAL development libraries." >&2
+            exit 1
+        fi
+    fi
     pip install -r requirements.txt >/dev/null
     pytest -m 'not qgis' "$@" test
 fi

--- a/scripts/run_qgis_tests.sh
+++ b/scripts/run_qgis_tests.sh
@@ -22,6 +22,15 @@ if command -v docker >/dev/null 2>&1; then
                 cd "${PLUGIN_DIR}"
                 export PYTHONPATH="${PLUGIN_DIR}:${PLUGIN_DIR}/test"
                 export PIP_BREAK_SYSTEM_PACKAGES=1
+                if ! command -v gdal-config >/dev/null 2>&1; then
+                    if command -v apt-get >/dev/null 2>&1; then
+                        apt-get update -qq
+                        apt-get install -y gdal-bin libgdal-dev >/dev/null
+                    else
+                        echo "gdal-config not found. Please install GDAL development libraries." >&2
+                        exit 1
+                    fi
+                fi
                 pip install -r requirements.txt >/dev/null
                 pytest -m 'not qgis' "$@" test
                 exit 0

--- a/test/test_assign_street_widths.py
+++ b/test/test_assign_street_widths.py
@@ -1,0 +1,43 @@
+import pytest
+
+pytest.importorskip("qgis")
+
+from qgis.core import QgsFeature, QgsField, QgsGeometry, QgsPointXY, QgsVectorLayer
+from qgis.PyQt.QtCore import QVariant
+
+from .utilities import get_qgis_app
+from generic_functions import assign_street_widths
+from parameters import default_widths
+
+pytestmark = pytest.mark.qgis
+
+
+@pytest.fixture(scope="module", autouse=True)
+def qgis_env():
+    app, _, _, _ = get_qgis_app()
+    assert app is not None
+    return app
+
+
+def _road_layer():
+    layer = QgsVectorLayer("LineString?crs=EPSG:4326", "roads", "memory")
+    dp = layer.dataProvider()
+    dp.addAttributes([QgsField("highway", QVariant.String)])
+    layer.updateFields()
+
+    feat = QgsFeature()
+    feat.setGeometry(QgsGeometry.fromPolylineXY([QgsPointXY(0, 0), QgsPointXY(1, 0)]))
+    feat.setAttribute("highway", "residential")
+    dp.addFeature(feat)
+    layer.updateExtents()
+    return layer
+
+
+def test_assign_street_widths_adds_default_width(qgis_env):
+    source = _road_layer()
+    out = assign_street_widths(source, "out")
+    assert out is not None
+    width_idx = out.fields().lookupField("width")
+    assert width_idx != -1
+    feat = next(out.getFeatures())
+    assert feat["width"] == default_widths["residential"]


### PR DESCRIPTION
## Summary
- prevent KeyError by setting street width using field name
- add regression test for street width assignment
- add GDAL dev dependency and restrict pytest discovery to the test directory
- install GDAL system libraries automatically when missing to support tests

## Testing
- `pip install -r requirements.txt`
- `pytest -m 'not qgis'`
- `scripts/run_qgis_tests.sh`


------
https://chatgpt.com/codex/tasks/task_b_689e335cb120832f8eecd60d3d4386a6