### PR TITLE
Fix spelling of Portuguese building labels

### DIFF
--- a/osm_sidewalkreator.py
+++ b/osm_sidewalkreator.py
@@ -539,12 +539,12 @@ class sidewalkreator:
             (
                 self.dlg.min_d_label,
                 "Min Distance\nto Buildings",
-                "Distância Mínima\np. Edificaçoes",
+                "Distância Mínima\np. Edificações",
             ),
             (
                 self.dlg.min_d_label,
                 "Min Distance\nto Buildings",
-                "Dist. Min.\np. Edificaçoes",
+                "Dist. Min.\np. Edificações",
             ),
             (self.dlg.curveradius_label, "Curve\nRadius", "Raio de\nCurvatura"),
             (


### PR DESCRIPTION
## Summary
- correct the Portuguese translation for the minimum distance to buildings labels

## Testing
- scripts/run_qgis_tests.sh

------
https://chatgpt.com/codex/tasks/task_b_68c8c6d11680832fbd7be58308fabafb