### PR TITLE
Clarify kerb percentage label

### DIFF
--- a/osm_sidewalkreator.py
+++ b/osm_sidewalkreator.py
@@ -567,7 +567,7 @@ class sidewalkreator:
                 "Subdividir Calçadas (Geometrias)",
             ),
             (self.dlg.perc_tol_crossings_label, "len.\ntol.", "tol.\ndist."),
-            (self.dlg.perc_draw_kerbs_label, "Kerbs\nat", "Kerb*\nem."),
+            (self.dlg.perc_draw_kerbs_label, "Kerbs\nat", "Guias\nem %"),
             (
                 self.dlg.opt_parallel_crossings,
                 "in parallel to\ntransversal seg.",


### PR DESCRIPTION
## Summary
- update the Portuguese kerb percentage label to read "Guias\nem %" for clarity

## Testing
- scripts/run_qgis_tests.sh


------
https://chatgpt.com/codex/tasks/task_b_68c8c6d133a4832fa60eb9f703de3aea