### PR TITLE
Adjust Portuguese hint punctuation

### DIFF
--- a/osm_sidewalkreator.py
+++ b/osm_sidewalkreator.py
@@ -1765,7 +1765,7 @@ class sidewalkreator:
 
         # hint texts:
         self.en_hint = "Hint: check for bad crossings using attrs.\nyou can delete them,\nkerbs are autom. cleaned!"
-        self.ptbr_hint = "Dica: Você pode\ndeletar manualmente cruzamentos\nvide a tabela de atributos para filtrar!"
+        self.ptbr_hint = "Dica: você pode deletar manualmente cruzamentos.\nVide a tabela de atributos para filtrar!"
         self.set_hint_text()
 
         # adding crossing len to check for "bad" crossings:


### PR DESCRIPTION
## Summary
- revise the Portuguese hint text to improve casing and punctuation

## Testing
- scripts/run_qgis_tests.sh

------
https://chatgpt.com/codex/tasks/task_b_68c8c6d461f8832fb8fe8480b7b40bba