### PR TITLE
Update Portuguese label for only facades option

### DIFF
--- a/osm_sidewalkreator.py
+++ b/osm_sidewalkreator.py
@@ -591,7 +591,7 @@ class sidewalkreator:
             ),
             (self.dlg.maxlensplit_checkbox, "Max Len.", "Larg. Máx."),
             (self.dlg.segsbynum_checkbox, "In x\nsegments", "Em x\nsegmentos"),
-            (self.dlg.onlyfacades_checkbox, "Only Facades", " Faces Q."),
+            (self.dlg.onlyfacades_checkbox, "Only Facades", "Somente Fachadas"),
             (self.dlg.dontsplit_checkbox, "Don't Split", "Não Dividir"),
             (
                 self.dlg.input_feature_text,


### PR DESCRIPTION
## Summary
- replace the Portuguese translation for the Only Facades checkbox with "Somente Fachadas"

## Testing
- scripts/run_qgis_tests.sh


------
https://chatgpt.com/codex/tasks/task_b_68c8c6d3064c832fbca847f291a95cdc